### PR TITLE
PR failed actions due to need for thread sleep to delay the dequing o…

### DIFF
--- a/Integ-Downlink-GroundSender.Tests/UnitTest1.cs
+++ b/Integ-Downlink-GroundSender.Tests/UnitTest1.cs
@@ -52,6 +52,7 @@ namespace Integ_Downlink_GroundSender.Tests
                 link.AddToQueue(testQueue.Dequeue());
             }
 
+            Thread.Sleep(1000);
             //Assert
             Assert.IsTrue(link.ReadytoTransmit(ground));
         }

--- a/Integ-Downlink-GroundSender.Tests/UnitTest1.cs
+++ b/Integ-Downlink-GroundSender.Tests/UnitTest1.cs
@@ -52,7 +52,7 @@ namespace Integ_Downlink_GroundSender.Tests
                 link.AddToQueue(testQueue.Dequeue());
             }
 
-            Thread.Sleep(1000);
+            while (!link.ReadytoTransmit(ground)) ;
             //Assert
             Assert.IsTrue(link.ReadytoTransmit(ground));
         }


### PR DESCRIPTION
…f transmissions to test the state before and after