### PR TITLE
Test Methods for "SendPing()" and the function itself have been updated

### DIFF
--- a/Integ-Uplink-SpaceSender/SpaceSender.cs
+++ b/Integ-Uplink-SpaceSender/SpaceSender.cs
@@ -191,6 +191,7 @@ public class SpaceSender
 
     private async void StartPingThread()
     {
+        TransmissionStatus = true;
         while (true)
         {
             try
@@ -242,7 +243,7 @@ public class SpaceSender
             {
                 transmissionManager_Ping = new Thread(delegate ()
                 {
-                    StartSendThread();
+                    StartPingThread();
                 });
                 transmissionManager_Ping.Start();
             }

--- a/Project 5/SpaceSender.cs
+++ b/Project 5/SpaceSender.cs
@@ -192,6 +192,7 @@ public class SpaceSender
 
     private async void StartPingThread()
     {
+        TransmissionStatus = true;
         while (true)
         {
             try
@@ -202,12 +203,12 @@ public class SpaceSender
                 if (response.IsSuccessStatusCode)
                 {
                     TransmissionStatus = true;
-                    Thread.Sleep(1000);
+                    Thread.Sleep(500);
                 }
                 else
                 {
                     TransmissionStatus = false;
-                    Thread.Sleep(1000);
+                    Thread.Sleep(500);
                 }
             }
             catch (HttpRequestException e)
@@ -243,7 +244,7 @@ public class SpaceSender
             {
                 transmissionManager_Ping = new Thread(delegate ()
                 {
-                    StartSendThread();
+                    StartPingThread();
                 });
                 transmissionManager_Ping.Start();
             }

--- a/Unit Tests/SpaceSender.Tests.cs
+++ b/Unit Tests/SpaceSender.Tests.cs
@@ -47,7 +47,7 @@ namespace Unit_Tests
         }
 
         [TestMethod]
-        public async Task SpaceSender_SendPing_SetStatusToTrueWhenPingResponseIsReceived()
+        public async Task SpaceSender_SendPing_SetStatus_To_True_When_PingIsSent()
         {
             var sender = new SpaceSender(testURL, ref queue, ref bufferlock);
             Assert.IsFalse(sender.TransmissionStatus); 
@@ -55,6 +55,17 @@ namespace Unit_Tests
             sender.SendPing();
             await Task.Delay(5000);
             Assert.IsTrue(sender.TransmissionStatus);
+        }
+
+        [TestMethod]
+        public void SpaceSender_SendPing_Strats_PingThread()
+        {
+            var sender = new SpaceSender(testURL, ref queue, ref bufferlock);
+            Assert.IsFalse(sender.IsRunning_Ping());
+
+            sender.SendPing();
+
+            Assert.IsTrue(sender.IsRunning_Ping());
         }
     }
 }


### PR DESCRIPTION
A new test method for "SendPing()" was created, and minor fixes were made to the function related to calling "StartPingThread()" instead of "StartSendThread()", and the delay time between pings.